### PR TITLE
Add support for routable_ip_or_net

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Here is a list of the available rules and their usage.
 [Private IPv4](#private_ipv4)<br/>
 [Private IPv6](#private_ipv6)<br/>
 [Private Net](#private_net)<br/>
+[Routable IP or Net](#routable_ip_or_net)<br/>
 [Routable IP](#routable_ip)<br/>
 [Routable IPv4](#routable_ipv4)<br/>
 [Routable IPv6](#routable_ipv6)<br/>
@@ -93,6 +94,10 @@ The networks considered private are described in the `private_ip` rule.
 ### private_net
 The field under validation must be a private IP network in CIDR notation.
 The networks considered private are described in the `private_ip` rule.
+
+### routable_ip_or_net
+The field under validation must be a globally routable IP address or network in CIDR notation.
+This excludes all private and reserved ranges, as detailed the the `private_ip` rule.
 
 ### routable_ip
 The field under validation must be a globally routable IPv4 or IPv6 address.

--- a/src/Providers/ValidationProvider.php
+++ b/src/Providers/ValidationProvider.php
@@ -18,6 +18,7 @@ class ValidationProvider extends ServiceProvider
             $validator->extend('routable_ip', Rules\RoutableIp::class . '@extend');
             $validator->extend('routable_net', Rules\RoutableNet::class . '@extend');
             $validator->extend('ip_or_net', Rules\IpOrNet::class . '@extend');
+            $validator->extend('routable_ip_or_net', Rules\RoutableIpOrNet::class . '@extend');
             $validator->extend('private_ipv4', Rules\PrivateIpv4::class . '@extend');
             $validator->extend('routable_ipv4', Rules\RoutableIpv4::class . '@extend');
             $validator->extend('netv4', Rules\Netv4::class . '@extend');

--- a/src/Rules/RoutableIpOrNet.php
+++ b/src/Rules/RoutableIpOrNet.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Miken32\Validation\Network\Rules;
+
+use Miken32\Validation\Network\Util;
+
+class RoutableIpOrNet extends BaseRule
+{
+    public function doValidation(string $attribute, string $value, ...$parameters): bool
+    {
+        return Util::validRoutableIPAddress($value) || Util::validRoutableIPNetwork($value);
+    }
+
+    public function message(): string
+    {
+        return __("The :attribute field must be a routable IP address or IP network in CIDR notation");
+    }
+}

--- a/tests/Feature/RoutableIpOrNetTest.php
+++ b/tests/Feature/RoutableIpOrNetTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Miken32\Validation\Tests\Feature;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use Miken32\Validation\Network\Rules;
+use Miken32\Validation\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(\Miken32\Validation\Network\Rules\RoutableIpOrNet::class)]
+class RoutableIpOrNetTest extends TestCase
+{
+    #[Test]
+    public function stringAccepts(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Validator::validate(
+            ['input_test' => '1.1.1.1'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+        Validator::validate(
+            ['input_test' => '2600:482e:1948::21'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+        Validator::validate(
+            ['input_test' => '1.1.1.1/29'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+        Validator::validate(
+            ['input_test' => '2600:2345:23ac::/56'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+    }
+
+    #[Test]
+    public function instanceAccepts(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Validator::validate(
+            ['input_test' => '1.1.1.1'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+        Validator::validate(
+            ['input_test' => '2600:482e:1948::21'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+        Validator::validate(
+            ['input_test' => '1.1.1.1/29'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+        Validator::validate(
+            ['input_test' => '2600:2345:23ac::/56'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+    }
+
+    #[Test]
+    public function stringRejectsIpv4(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => '10.5.38.218'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => $this->faker->localIpv4 . '/23'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+    }
+
+    #[Test]
+    public function stringRejectsIpv6(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => '2001:0000:0000::f298'],
+            ['input_test' => 'routable_ip_or_net']
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        $v6 = $this->faker->ipv6;
+        $v6 = 'fd00' . substr($v6, strpos($v6, ':')) . '/64';
+        Validator::validate(
+            ['input_test' => $v6],
+            ['input_test' => 'routable_ip_or_net']
+        );
+    }
+
+    #[Test]
+    public function instanceRejectsIpv4(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => '10.5.38.218'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => $this->faker->localIpv4 . '/23'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+    }
+
+    #[Test]
+    public function instanceRejectsIpv6(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        Validator::validate(
+            ['input_test' => '2001:0000:0000::f298'],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The input test field must be a routable IP address or IP network in CIDR notation');
+        $v6 = $this->faker->ipv6;
+        $v6 = 'fd00' . substr($v6, strpos($v6, ':')) . '/64';
+        Validator::validate(
+            ['input_test' => $v6],
+            ['input_test' => new Rules\RoutableIpOrNet()]
+        );
+    }
+
+}


### PR DESCRIPTION
Joins together the two routable rules to allow user submission of either a routable IP or Subnet.

In our case we needed to allow the user to enter either a routable IP address or routable subnet. Currently this does not seem easy to achieve without a custom validation callback, so thought I would add a PR to add this to the package natively.

Thanks for the package!